### PR TITLE
Fixed nuxt version

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "axios": "^0.16.2",
     "gsap": "^1.19.1",
-    "nuxt": "^1.0.0-alpha4",
+    "nuxt": "^1.0.0-alpha.4",
     "nuxt-class-component": "^1.0.1",
     "tachyons": "^4.7.4",
     "vue-class-component": "^5.0.1",


### PR DESCRIPTION
Fixed the nuxt version that generate the error 
```
npm ERR! code ETARGET
npm ERR! notarget No matching version found for nuxt@^1.0.0-alpha4
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```