### PR TITLE
Update nuxt-property-decorator dependency to fix nuxt-community/typescript-template#44

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.0.0",
     "nuxt": "^1.3.0",
-    "nuxt-property-decorator": "^1.0.0",
+    "nuxt-property-decorator": "^1.1.3",
     "vuex-class": "^0.3.0"
   },
   "scripts": {


### PR DESCRIPTION
Previous version of nuxt-property-decorator doesn't include or build the `main` file specified in it's `package.json, new version points to correctly build `js` file instead of the non-existent `umd`.