### PR TITLE
Remove unnecessary typedefs

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -17,7 +17,6 @@
     "generate": "nuxt-ts generate"
   },
   "devDependencies": {
-    "@nuxt/typescript-build": "0.2.6",
-    "@types/webpack-env": "1.14.0"
+    "@nuxt/typescript-build": "0.2.6"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@nuxt/typescript-build": "0.2.6",
-    "@types/node": "10.14.17",
     "@types/webpack-env": "1.14.0"
   }
 }

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -20,7 +20,6 @@
       "~/*": ["./*"]
     },
     "types": [
-      "@types/node",
       "@types/webpack-env",
       "@nuxt/types"
     ]

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -20,7 +20,6 @@
       "~/*": ["./*"]
     },
     "types": [
-      "@types/webpack-env",
       "@nuxt/types"
     ]
   }


### PR DESCRIPTION
`@nuxt/typescript-build` installs `@nuxt/types` which depends on many type modules from DefinitelyTyped. https://github.com/nuxt/typescript/blob/master/packages/types/package.json

- `@types/node` is provided through that, so we don't need to have explicitly
    - e.g. `process.env` is typed on the codebase
- `@types/webpack-env` is no longer needed (I'm not sure why I kept)
    - e.g. `require.context` is typed if we need to load files programmatically