### PR TITLE
chore: add shebang to init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 delete_composition()
 {
   rm pages/composition-api.vue


### PR DESCRIPTION
## Overview

Hi, there.
I run the below command, and encounter a syntax error in Ubuntu 20.04 environment. Ubuntu uses dash to run shell scripts as default, and dash cannot interpret `select .. in` statement in `init.sh`. 

```bash
$ ./init.sh
./init.sh: 48: Syntax error: "do" unexpected (expecting ";;")
```

So, I think specifying the interpreter by sheabang enable to support almost all environments.
